### PR TITLE
Add GPU transform and DiceCE training pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,7 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+src/py/lightning_logs/
+*.ckpt
+*.pkl
+__pycache__/

--- a/src/py/3.eval.py
+++ b/src/py/3.eval.py
@@ -1,14 +1,50 @@
-import pandas as pd, os
+import argparse
+import os
 
-test_csv = "/home/yin816/tt_training/practice/test.csv"
-pred_root = "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/pred_test"
-out_csv = "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/test_eval.csv"
+import pandas as pd
 
-df = pd.read_csv(test_csv)
 
-df["pred"] = df["img"].apply(
-    lambda x: os.path.join(pred_root, os.path.splitext(x)[0] + ".nrrd")
-)
+def main(args):
 
-df.to_csv(out_csv, index=False)
-print(out_csv)
+    df = pd.read_csv(args.test_csv)
+
+    df["pred"] = df["img"].apply(
+        lambda x: os.path.join(
+            args.pred_root,
+            os.path.splitext(x)[0] + ".nrrd"
+        )
+    )
+
+    df.to_csv(args.out_csv, index=False)
+
+    print(args.out_csv)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--test_csv",
+        type=str,
+        required=True,
+        help="path to original test csv"
+    )
+
+    parser.add_argument(
+        "--pred_root",
+        type=str,
+        required=True,
+        help="root directory containing predicted nrrd files"
+    )
+
+    parser.add_argument(
+        "--out_csv",
+        type=str,
+        required=True,
+        help="output evaluation csv"
+    )
+
+    args = parser.parse_args()
+
+    main(args)

--- a/src/py/3.eval.py
+++ b/src/py/3.eval.py
@@ -1,0 +1,14 @@
+import pandas as pd, os
+
+test_csv = "/home/yin816/tt_training/practice/test.csv"
+pred_root = "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/pred_test"
+out_csv = "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/test_eval.csv"
+
+df = pd.read_csv(test_csv)
+
+df["pred"] = df["img"].apply(
+    lambda x: os.path.join(pred_root, os.path.splitext(x)[0] + ".nrrd")
+)
+
+df.to_csv(out_csv, index=False)
+print(out_csv)

--- a/src/py/eval_seg_pkl.py
+++ b/src/py/eval_seg_pkl.py
@@ -1,0 +1,210 @@
+from __future__ import print_function
+
+import argparse
+import itertools
+import os
+import pickle
+
+import matplotlib as mpl
+mpl.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+import SimpleITK as sitk
+from sklearn.metrics import classification_report, confusion_matrix, jaccard_score
+
+
+def plot_confusion_matrix(cm, classes, normalize=False, title="Confusion matrix", cmap=plt.cm.Blues):
+    if normalize:
+        row_sums = cm.sum(axis=1, keepdims=True)
+        cm = np.divide(
+            cm.astype(float),
+            row_sums,
+            out=np.zeros_like(cm, dtype=float),
+            where=row_sums != 0,
+        )
+        print("Normalized confusion matrix")
+    else:
+        print("Confusion matrix, without normalization")
+
+    print(cm)
+
+    plt.imshow(cm, interpolation="nearest", cmap=cmap)
+    plt.title(title)
+    plt.colorbar()
+    tick_marks = np.arange(len(classes))
+    plt.xticks(tick_marks, classes, rotation=45)
+    plt.yticks(tick_marks, classes)
+
+    fmt = ".3f" if normalize else "d"
+    thresh = cm.max() / 2.0 if cm.size > 0 else 0
+
+    for i, j in itertools.product(range(cm.shape[0]), range(cm.shape[1])):
+        plt.text(
+            j,
+            i,
+            format(cm[i, j], fmt),
+            horizontalalignment="center",
+            color="white" if cm[i, j] > thresh else "black",
+        )
+
+    plt.ylabel("True label")
+    plt.xlabel("Predicted label")
+    plt.tight_layout()
+
+    return cm
+
+
+def read_true_seg(seg_path, csv_root=None):
+    if csv_root and not os.path.isabs(seg_path):
+        seg_path = os.path.join(csv_root, seg_path)
+
+    if seg_path.endswith(".pkl"):
+        with open(seg_path, "rb") as f:
+            d = pickle.load(f)
+
+        y_true = d["seg"]
+
+        if hasattr(y_true, "detach"):
+            y_true = y_true.detach().cpu().numpy()
+
+        y_true = np.squeeze(y_true)
+        return y_true
+
+    return sitk.GetArrayFromImage(sitk.ReadImage(seg_path))
+
+
+def read_pred_seg(pred_path):
+    y_pred = sitk.GetArrayFromImage(sitk.ReadImage(pred_path))
+
+    if y_pred.ndim >= 3 and y_pred.shape[-1] > 1:
+        y_pred = np.argmax(y_pred, axis=-1)
+
+    y_pred = np.squeeze(y_pred)
+    return y_pred
+
+
+def match_shapes(y_true, y_pred):
+    if y_true.shape != y_pred.shape:
+        print("Shape mismatch:", y_true.shape, y_pred.shape)
+
+        h = min(y_true.shape[0], y_pred.shape[0])
+        w = min(y_true.shape[1], y_pred.shape[1])
+
+        y_true = y_true[:h, :w]
+        y_pred = y_pred[:h, :w]
+
+    return y_true, y_pred
+
+
+def main(args):
+    df = pd.read_csv(args.csv)
+    labels = list(range(args.num_classes))
+
+    dice_arr = []
+    cnf_matrix_arr = []
+    cl_report_arr = []
+
+    for i, row in df.iterrows():
+        print("Reading:", row[args.seg_column])
+        y_true = read_true_seg(row[args.seg_column], csv_root=args.csv_root)
+
+        print("Reading:", row[args.pred_column])
+        y_pred = read_pred_seg(row[args.pred_column])
+
+        y_true, y_pred = match_shapes(y_true, y_pred)
+
+        y_true = np.reshape(y_true, -1).astype(int)
+        y_pred = np.reshape(y_pred, -1).astype(int)
+
+        cnf_matrix = confusion_matrix(y_true, y_pred, labels=labels)
+
+        row_sums = cnf_matrix.sum(axis=1, keepdims=True)
+        cnf_matrix_norm = np.divide(
+            cnf_matrix.astype(float),
+            row_sums,
+            out=np.zeros_like(cnf_matrix, dtype=float),
+            where=row_sums != 0,
+        )
+
+        cnf_matrix_arr.append(cnf_matrix_norm)
+        print(cnf_matrix_norm)
+
+        cl_report = classification_report(
+            y_true,
+            y_pred,
+            labels=labels,
+            output_dict=True,
+            zero_division=0,
+        )
+        cl_report_arr.append(cl_report)
+        print(cl_report)
+
+        jaccard = jaccard_score(
+            y_true,
+            y_pred,
+            labels=labels,
+            average=None,
+            zero_division=0,
+        )
+
+        dice = 2.0 * jaccard / (1.0 + jaccard)
+        print(dice)
+
+        dice_arr.append(dice)
+
+    out_base = os.path.splitext(args.csv)[0]
+
+    pickle.dump(
+        cl_report_arr,
+        open(out_base + "_classification_report.pickle", "wb"),
+    )
+    pickle.dump(
+        cnf_matrix_arr,
+        open(out_base + "_confusion_matrix.pickle", "wb"),
+    )
+
+    dice_arr = np.array(dice_arr)
+    print(dice_arr.shape)
+
+    np.save(out_base + "_violin_plot.npy", dice_arr)
+
+    fig3 = plt.figure(figsize=(8, 5))
+    try:
+        s = sns.violinplot(data=dice_arr, cut=0, density_norm="count")
+    except TypeError:
+        s = sns.violinplot(data=dice_arr, cut=0, scale="count")
+
+    s.set_title("Dice coefficients")
+    s.set_xlabel("Class")
+    s.set_ylabel("Dice")
+    s.set_xticklabels([str(i) for i in labels])
+
+    violin_filename = out_base + "_violin_plot.png"
+    fig3.savefig(violin_filename, bbox_inches="tight", dpi=200)
+
+    dice_df = pd.DataFrame(
+        dice_arr,
+        columns=[f"dice_class_{i}" for i in labels],
+    )
+
+    df_out = pd.concat([df.reset_index(drop=True), dice_df], axis=1)
+    df_out.to_csv(args.csv.replace(".csv", "_dice.csv"), index=False)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Evaluate segmentation predictions for pkl ground truth and nrrd predictions",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+
+    input_param_group = parser.add_argument_group("Input")
+    input_param_group.add_argument("--csv", type=str, help="CSV file with segmentation and prediction columns", required=True)
+    input_param_group.add_argument("--seg_column", type=str, help="column name for ground-truth segmentation/pkl", default="seg")
+    input_param_group.add_argument("--pred_column", type=str, help="column name for prediction", default="pred")
+    input_param_group.add_argument("--csv_root", type=str, help="root path for relative pkl paths", default=None)
+    input_param_group.add_argument("--num_classes", type=int, help="number of segmentation classes", default=7)
+
+    args = parser.parse_args()
+    main(args)

--- a/src/py/eval_seg_pkl.py
+++ b/src/py/eval_seg_pkl.py
@@ -141,17 +141,23 @@ def main(args):
         cl_report_arr.append(cl_report)
         print(cl_report)
 
-        jaccard = jaccard_score(
-            y_true,
-            y_pred,
-            labels=labels,
-            average=None,
-            zero_division=0,
-        )
+        dice = np.full(args.num_classes, np.nan)
 
-        dice = 2.0 * jaccard / (1.0 + jaccard)
+        for c in labels:
+            true_c = (y_true == c)
+            pred_c = (y_pred == c)
+        
+            true_sum = true_c.sum()
+            pred_sum = pred_c.sum()
+        
+            # no class i in both GT and prediction: do not count
+            if true_sum == 0 and pred_sum == 0:
+                dice[c] = np.nan
+            else:
+                intersection = np.logical_and(true_c, pred_c).sum()
+                dice[c] = 2.0 * intersection / (true_sum + pred_sum)
+        
         print(dice)
-
         dice_arr.append(dice)
 
     out_base = os.path.splitext(args.csv)[0]
@@ -166,15 +172,16 @@ def main(args):
     )
 
     dice_arr = np.array(dice_arr)
+    dice_arr_plot = pd.DataFrame(dice_arr, columns=[f"class_{i}" for i in labels])
     print(dice_arr.shape)
 
     np.save(out_base + "_violin_plot.npy", dice_arr)
 
     fig3 = plt.figure(figsize=(8, 5))
     try:
-        s = sns.violinplot(data=dice_arr, cut=0, density_norm="count")
+        s = sns.violinplot(data=dice_arr_plot, cut=0, density_norm="count")
     except TypeError:
-        s = sns.violinplot(data=dice_arr, cut=0, scale="count")
+        s = sns.violinplot(data=dice_arr_plot, cut=0, scale="count")
 
     s.set_title("Dice coefficients")
     s.set_xlabel("Class")

--- a/src/py/export_seg_torchscript.py
+++ b/src/py/export_seg_torchscript.py
@@ -1,0 +1,23 @@
+import torch
+from nets.segmentation import TTUNet
+
+CKPT = "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/epoch=16-val_loss=1.53.ckpt"
+
+model = TTUNet.load_from_checkpoint(
+    CKPT,
+    out_channels=7,
+)
+
+model.eval()
+model.cpu()
+
+example_input = torch.randn(1, 3, 512, 512)
+
+traced = torch.jit.trace(model.model, example_input)
+
+torch.jit.save(
+    traced,
+    "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/model_nocj_epoch=16-val_loss=1.53.ts"
+)
+
+print("saved")

--- a/src/py/export_seg_torchscript.py
+++ b/src/py/export_seg_torchscript.py
@@ -1,23 +1,52 @@
+import os
+import argparse
+
 import torch
+
 from nets.segmentation import TTUNet
 
-CKPT = "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/epoch=16-val_loss=1.53.ckpt"
 
-model = TTUNet.load_from_checkpoint(
-    CKPT,
-    out_channels=7,
-)
+def main(args):
 
-model.eval()
-model.cpu()
+    model = TTUNet.load_from_checkpoint(
+        args.ckpt,
+        out_channels=args.out_channels,
+    )
 
-example_input = torch.randn(1, 3, 512, 512)
+    model.eval()
+    model.cpu()
 
-traced = torch.jit.trace(model.model, example_input)
+    example_input = torch.randn(1, 3, 512, 512)
 
-torch.jit.save(
-    traced,
-    "/home/yin816/tt_training/output/seg_run_gpu_trans_dicece_sqrt/model_nocj_epoch=16-val_loss=1.53.ts"
-)
+    traced = torch.jit.trace(model.model, example_input)
 
-print("saved")
+    out_ts = os.path.splitext(args.ckpt)[0] + ".ts"
+
+    torch.jit.save(
+        traced,
+        out_ts
+    )
+
+    print("saved:", out_ts)
+
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument(
+        "--ckpt",
+        type=str,
+        required=True,
+        help="path to checkpoint"
+    )
+
+    parser.add_argument(
+        "--out_channels",
+        type=int,
+        default=7,
+    )
+
+    args = parser.parse_args()
+
+    main(args)

--- a/src/py/loaders/tt_dataset.py
+++ b/src/py/loaders/tt_dataset.py
@@ -1910,12 +1910,12 @@ class TTDataModuleSegPklGPUResize(pl.LightningDataModule):
         self.num_workers = num_workers
         self.drop_last = True
 
-        cj = transforms.ColorJitter(
-            brightness=[.8, 1.2],
-            contrast=[0.8, 1.2],
-            saturation=[.8, 1.2],
-            hue=[-.1, .1],
-        )
+        # cj = transforms.ColorJitter(
+        #     brightness=[.8, 1.2],
+        #     contrast=[0.8, 1.2],
+        #     saturation=[.8, 1.2],
+        #     hue=[-.1, .1],
+        # )
 
         # train: light CPU transform only
         # img: [1, 3, H, W] -> [3, H, W]
@@ -1924,7 +1924,7 @@ class TTDataModuleSegPklGPUResize(pl.LightningDataModule):
             Lambdad(keys=["img"], func=lambda x: x.squeeze(0) if x.ndim == 4 else x),
             Lambdad(keys=["seg"], func=lambda x: x if x.ndim == 3 else x.unsqueeze(0)),
             ScaleIntensityd(keys=["img"]),
-            Lambdad(keys=["img"], func=lambda x: cj(x)),
+            # Lambdad(keys=["img"], func=lambda x: cj(x)),
         ])
 
         # val/test: deterministic fixed size

--- a/src/py/loaders/tt_dataset.py
+++ b/src/py/loaders/tt_dataset.py
@@ -1605,7 +1605,7 @@ class BBXImageTestTransform():
 
     def __call__(self, image, bboxes, category_ids, mask=None):
         return self.transform(image=image, bboxes=bboxes, category_ids=category_ids, mask=mask)
-    
+
 
 class TTDatasetSegPkl(Dataset):
     def __init__(self, df, mount_point="./", transform=monai.transforms.Identityd(keys=["img", "seg"])):
@@ -1635,7 +1635,8 @@ class TTDatasetSegPkl(Dataset):
 
         return self.transform(sample)
 
-
+        
+        
 class TTDataModuleSegPkl(pl.LightningDataModule):
     def __init__(self, df_train, df_val, df_test, mount_point="./", batch_size=256, num_workers=4):
         super().__init__()
@@ -1679,3 +1680,325 @@ class TTDataModuleSegPkl(pl.LightningDataModule):
 
     def test_dataloader(self):
         return DataLoader(self.test_ds, batch_size=self.batch_size, num_workers=self.num_workers, drop_last=self.drop_last)
+        
+# no GPU for transform       
+class TTDataModuleSegPklTrans(pl.LightningDataModule):
+    def __init__(self, df_train, df_val, df_test, mount_point="./", batch_size=256, num_workers=4):
+        super().__init__()
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.df_test = df_test
+        self.mount_point = mount_point
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.drop_last = True
+
+        cj = transforms.ColorJitter(
+            brightness=[.8, 1.2],
+            contrast=[0.8, 1.2],
+            saturation=[.8, 1.2],
+            hue=[-.1, .1],
+        )
+
+        self.train_transform = Compose([
+            # pkl: img [1, 3, H, W] -> [3, H, W]
+            Lambdad(keys=["img"], func=lambda x: x.squeeze(0) if x.ndim == 4 else x),
+
+            # pkl: seg [1, H, W] should stay [1, H, W]
+            # do NOT squeeze to [H, W], otherwise spatial transform may misread H as channel/depth
+            Lambdad(keys=["seg"], func=lambda x: x if x.ndim == 3 else x.unsqueeze(0)),
+
+            RandZoomRotateResizedGridTorch(
+                keys=["img", "seg"],
+                out_size=(512, 512),
+                prob=0.8,
+                zoom_range=(0.2, 1.5),
+                angle_range=(-90, 90),
+                mode_map={"img": "bilinear", "seg": "nearest"},
+                padding_mode="border",
+            ),
+
+            ResizeIfNeededInterpolateTorch(
+                keys=["img", "seg"],
+                out_size=(512, 512),
+                mode_map={"img": "bilinear", "seg": "nearest"},
+                antialias_map={"img": True},
+            ),
+
+            ScaleIntensityd(keys=["img"]),
+            Lambdad(keys=["img"], func=lambda x: cj(x)),
+        ])
+
+        self.val_transform = Compose([
+            Lambdad(keys=["img"], func=lambda x: x.squeeze(0) if x.ndim == 4 else x),
+            Lambdad(keys=["seg"], func=lambda x: x if x.ndim == 3 else x.unsqueeze(0)),
+            Resized(keys=["img", "seg"], spatial_size=[512, 512], mode=["area", "nearest"]),
+            ScaleIntensityd(keys=["img"]),
+        ])
+
+        self.test_transform = Compose([
+            Lambdad(keys=["img"], func=lambda x: x.squeeze(0) if x.ndim == 4 else x),
+            Lambdad(keys=["seg"], func=lambda x: x if x.ndim == 3 else x.unsqueeze(0)),
+            Resized(keys=["img", "seg"], spatial_size=[512, 512], mode=["area", "nearest"]),
+            ScaleIntensityd(keys=["img"]),
+        ])
+
+    def setup(self, stage=None):
+        self.train_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(self.df_train, mount_point=self.mount_point),
+            transform=self.train_transform,
+        )
+
+        self.val_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(self.df_val, mount_point=self.mount_point),
+            transform=self.val_transform,
+        )
+
+        self.test_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(self.df_test, mount_point=self.mount_point),
+            transform=self.test_transform,
+        )
+
+    def train_dataloader(self):
+        return DataLoader(
+            self.train_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            shuffle=True,
+            prefetch_factor=2,
+            pin_memory=True,
+            persistent_workers=True,
+            collate_fn=pad_list_data_collate,
+        )
+
+    def val_dataloader(self):
+        return DataLoader(
+            self.val_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            collate_fn=pad_list_data_collate,
+        )
+
+    def test_dataloader(self):
+        return DataLoader(
+            self.test_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            collate_fn=pad_list_data_collate,
+        )
+
+class TTDataModuleSegPklGPUTrans(pl.LightningDataModule):
+    def __init__(self, df_train, df_val, df_test, mount_point="./", batch_size=1, num_workers=4):
+        super().__init__()
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.df_test = df_test
+        self.mount_point = mount_point
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.drop_last = True
+
+        cj = transforms.ColorJitter(
+            brightness=[.8, 1.2],
+            contrast=[0.8, 1.2],
+            saturation=[.8, 1.2],
+            hue=[-.1, .1],
+        )
+
+        # train: light CPU transform only
+        # heavy random resize/rotation/zoom should be done in TTUNet.training_step on GPU
+        self.train_transform = Compose([
+            ScaleIntensityd(keys=["img"]),
+            Lambdad(keys=["img"], func=lambda x: cj(x)),
+        ])
+
+        # val/test: deterministic fixed size
+        self.val_transform = Compose([
+            Resized(
+                keys=["img", "seg"],
+                spatial_size=[512, 512],
+                mode=["area", "nearest"],
+            ),
+            ScaleIntensityd(keys=["img"]),
+        ])
+
+        self.test_transform = Compose([
+            Resized(
+                keys=["img", "seg"],
+                spatial_size=[512, 512],
+                mode=["area", "nearest"],
+            ),
+            ScaleIntensityd(keys=["img"]),
+        ])
+
+    def setup(self, stage=None):
+        self.train_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(
+                self.df_train,
+                mount_point=self.mount_point,
+                transform=self.train_transform,
+            )
+        )
+
+        self.val_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(
+                self.df_val,
+                mount_point=self.mount_point,
+                transform=self.val_transform,
+            )
+        )
+
+        self.test_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(
+                self.df_test,
+                mount_point=self.mount_point,
+                transform=self.test_transform,
+            )
+        )
+
+    def train_dataloader(self):
+        return DataLoader(
+            self.train_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            shuffle=True,
+            prefetch_factor=2,
+            pin_memory=True,
+            persistent_workers=True,
+        )
+
+    def val_dataloader(self):
+        return DataLoader(
+            self.val_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            collate_fn=pad_list_data_collate,
+            prefetch_factor=2,
+            pin_memory=True,
+            persistent_workers=True,
+        )
+
+    def test_dataloader(self):
+        return DataLoader(
+            self.test_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            collate_fn=pad_list_data_collate,
+            prefetch_factor=2,
+            pin_memory=True,
+            persistent_workers=True,
+        )
+        
+# to use DiceCELoss
+class TTDataModuleSegPklGPUResize(pl.LightningDataModule):
+    def __init__(self, df_train, df_val, df_test, mount_point="./", batch_size=1, num_workers=4):
+        super().__init__()
+
+        self.df_train = df_train
+        self.df_val = df_val
+        self.df_test = df_test
+        self.mount_point = mount_point
+        self.batch_size = batch_size
+        self.num_workers = num_workers
+        self.drop_last = True
+
+        cj = transforms.ColorJitter(
+            brightness=[.8, 1.2],
+            contrast=[0.8, 1.2],
+            saturation=[.8, 1.2],
+            hue=[-.1, .1],
+        )
+
+        # train: light CPU transform only
+        # img: [1, 3, H, W] -> [3, H, W]
+        # seg: keep [1, H, W] for Dice/DiceCE loss
+        self.train_transform = Compose([
+            Lambdad(keys=["img"], func=lambda x: x.squeeze(0) if x.ndim == 4 else x),
+            Lambdad(keys=["seg"], func=lambda x: x if x.ndim == 3 else x.unsqueeze(0)),
+            ScaleIntensityd(keys=["img"]),
+            Lambdad(keys=["img"], func=lambda x: cj(x)),
+        ])
+
+        # val/test: deterministic fixed size
+        self.val_transform = Compose([
+            Lambdad(keys=["img"], func=lambda x: x.squeeze(0) if x.ndim == 4 else x),
+            Lambdad(keys=["seg"], func=lambda x: x if x.ndim == 3 else x.unsqueeze(0)),
+            Resized(keys=["img", "seg"], spatial_size=[512, 512], mode=["area", "nearest"]),
+            ScaleIntensityd(keys=["img"]),
+        ])
+
+        self.test_transform = Compose([
+            Lambdad(keys=["img"], func=lambda x: x.squeeze(0) if x.ndim == 4 else x),
+            Lambdad(keys=["seg"], func=lambda x: x if x.ndim == 3 else x.unsqueeze(0)),
+            Resized(keys=["img", "seg"], spatial_size=[512, 512], mode=["area", "nearest"]),
+            ScaleIntensityd(keys=["img"]),
+        ])
+
+    def setup(self, stage=None):
+        self.train_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(
+                self.df_train,
+                mount_point=self.mount_point,
+                transform=self.train_transform,
+            )
+        )
+
+        self.val_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(
+                self.df_val,
+                mount_point=self.mount_point,
+                transform=self.val_transform,
+            )
+        )
+
+        self.test_ds = monai.data.Dataset(
+            data=TTDatasetSegPkl(
+                self.df_test,
+                mount_point=self.mount_point,
+                transform=self.test_transform,
+            )
+        )
+
+    def train_dataloader(self):
+        return DataLoader(
+            self.train_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            shuffle=True,
+            prefetch_factor=2,
+            pin_memory=True,
+            persistent_workers=True,
+        )
+
+    def val_dataloader(self):
+        return DataLoader(
+            self.val_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            collate_fn=pad_list_data_collate,
+            prefetch_factor=2,
+            pin_memory=True,
+            persistent_workers=True,
+        )
+
+    def test_dataloader(self):
+        return DataLoader(
+            self.test_ds,
+            batch_size=self.batch_size,
+            num_workers=self.num_workers,
+            drop_last=self.drop_last,
+            collate_fn=pad_list_data_collate,
+            prefetch_factor=2,
+            pin_memory=True,
+            persistent_workers=True,
+        )

--- a/src/py/nets/segmentation.py
+++ b/src/py/nets/segmentation.py
@@ -455,6 +455,84 @@ class TTUNet(pl.LightningModule):
     def predict_step(self, images):
         return torch.argmax(self(images), dim=1, keepdim=True)
 
+
+class TTUNet(pl.LightningModule):
+    def __init__(self, **kwargs):
+        super(TTUNet, self).__init__()        
+        
+        self.save_hyperparameters()
+
+        if hasattr(self.hparams, "ce_weight") and self.hparams.ce_weight is not None:
+            self.loss = monai.losses.DiceCELoss(include_background=False, to_onehot_y=True, softmax=True, ce_weight=torch.tensor(self.hparams.ce_weight), lambda_dice=1.0, lambda_ce=1.0)
+        else:
+            self.loss = monai.losses.DiceLoss(include_background=False, softmax=True, to_onehot_y=True)
+        
+
+        self.accuracy = torchmetrics.Accuracy(task='multiclass', num_classes=self.hparams.out_channels)
+
+        self.model = monai.networks.nets.UNet(spatial_dims=2, in_channels=3, out_channels=self.hparams.out_channels, channels=(16, 32, 64, 128, 256, 512, 1024), strides=(2, 2, 2, 2, 2, 2), num_res_units=4)
+        # self.metric = DiceMetric(include_background=True, reduction="mean") 
+         
+        self.train_transform = monai.transforms.Compose([
+            RandZoomRotateResizedGridTorch(keys=["img", "seg"], out_size=(512, 512), prob=0.9, zoom_range=(0.2, 1.5), angle_range=(-90, 90), mode_map={"img": "bilinear", "seg": "nearest"}, padding_mode="border",),
+                ResizeIfNeededInterpolateTorch(keys=["img", "seg"], out_size=(512, 512), mode_map={"img": "bilinear", "seg": "nearest"}, antialias_map={"img": True}),
+        ])  
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
+        return optimizer
+
+    def forward(self, x):
+        return self.model(x)
+
+    def training_step(self, train_batch, batch_idx):
+        
+        train_batch = self.train_transform(train_batch)
+        
+        x = train_batch["img"]
+        y = train_batch["seg"]
+        
+        y = y.to(torch.int64)
+        x = self.model(x)
+
+        loss = self.loss(x, y)
+        
+        batch_size = x.shape[0]
+        self.log('train_loss', loss, batch_size=batch_size)        
+
+        # x = torch.argmax(x, dim=1, keepdim=True)
+        
+        return loss
+
+    def validation_step(self, val_batch, batch_idx):
+        x = val_batch["img"]
+        y = val_batch["seg"]
+        
+        y = y.to(torch.int64)
+        x = self.model(x)
+        
+        loss = self.loss(x, y)
+        
+        batch_size = x.shape[0]
+        self.log('val_loss', loss, batch_size=batch_size, sync_dist=True)
+
+    def test_step(self, test_batch, batch_idx):
+        x = test_batch["img"]
+        y = test_batch["seg"]
+        
+        y = y.to(torch.int64)
+        x = self.model(x)
+        
+        loss = self.loss(x, y)
+        
+        batch_size = x.shape[0]
+        self.log('test_loss', loss, batch_size=batch_size)
+        # x = torch.argmax(x, dim=1, keepdim=True)
+
+    def predict_step(self, images):
+        return torch.argmax(self(images), dim=1, keepdim=True)
+
+
 class TTRCNN(pl.LightningModule):
     def __init__(self, device='cuda', **kwargs):
         super(TTRCNN, self).__init__()        

--- a/src/py/nets/segmentation.py
+++ b/src/py/nets/segmentation.py
@@ -379,81 +379,6 @@ class ResizeIfNeededInterpolateTorch:
         return out
     
 
-class TTUNet(pl.LightningModule):
-    def __init__(self, **kwargs):
-        super(TTUNet, self).__init__()        
-        
-        self.save_hyperparameters()
-
-        if hasattr(self.hparams, "ce_weight") and self.hparams.ce_weight is not None:
-            self.loss = monai.losses.DiceCELoss(include_background=False, to_onehot_y=True, softmax=True, weight=torch.tensor(self.hparams.ce_weight), lambda_dice=1.0, lambda_ce=1.0)
-        else:
-            self.loss = monai.losses.DiceLoss(include_background=False, softmax=True, to_onehot_y=True)
-        
-
-        self.accuracy = torchmetrics.Accuracy(task='multiclass', num_classes=self.hparams.out_channels)
-
-        self.model = monai.networks.nets.UNet(spatial_dims=2, in_channels=3, out_channels=self.hparams.out_channels, channels=(16, 32, 64, 128, 256, 512, 1024), strides=(2, 2, 2, 2, 2, 2), num_res_units=4)
-        # self.metric = DiceMetric(include_background=True, reduction="mean") 
-         
-        self.train_transform = monai.transforms.Compose([
-            RandZoomRotateResizedGridTorch(keys=["img", "seg"], out_size=(512, 512), prob=0.9, zoom_range=(0.2, 1.5), angle_range=(-90, 90), mode_map={"img": "bilinear", "seg": "nearest"}, padding_mode="border",),
-                ResizeIfNeededInterpolateTorch(keys=["img", "seg"], out_size=(512, 512), mode_map={"img": "bilinear", "seg": "nearest"}, antialias_map={"img": True}),
-        ])  
-
-    def configure_optimizers(self):
-        optimizer = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
-        return optimizer
-
-    def forward(self, x):
-        return self.model(x)
-
-    def training_step(self, train_batch, batch_idx):
-        
-        train_batch = self.train_transform(train_batch)
-        
-        x = train_batch["img"]
-        y = train_batch["seg"]
-        
-        y = y.to(torch.int64)
-        x = self.model(x)
-
-        loss = self.loss(x, y)
-        
-        batch_size = x.shape[0]
-        self.log('train_loss', loss, batch_size=batch_size)        
-
-        # x = torch.argmax(x, dim=1, keepdim=True)
-        
-        return loss
-
-    def validation_step(self, val_batch, batch_idx):
-        x = val_batch["img"]
-        y = val_batch["seg"]
-        
-        y = y.to(torch.int64)
-        x = self.model(x)
-        
-        loss = self.loss(x, y)
-        
-        batch_size = x.shape[0]
-        self.log('val_loss', loss, batch_size=batch_size, sync_dist=True)
-
-    def test_step(self, test_batch, batch_idx):
-        x = test_batch["img"]
-        y = test_batch["seg"]
-        
-        y = y.to(torch.int64)
-        x = self.model(x)
-        
-        loss = self.loss(x, y)
-        
-        batch_size = x.shape[0]
-        self.log('test_loss', loss, batch_size=batch_size)
-        # x = torch.argmax(x, dim=1, keepdim=True)
-
-    def predict_step(self, images):
-        return torch.argmax(self(images), dim=1, keepdim=True)
 
 
 class TTUNet(pl.LightningModule):
@@ -477,6 +402,10 @@ class TTUNet(pl.LightningModule):
             RandZoomRotateResizedGridTorch(keys=["img", "seg"], out_size=(512, 512), prob=0.9, zoom_range=(0.2, 1.5), angle_range=(-90, 90), mode_map={"img": "bilinear", "seg": "nearest"}, padding_mode="border",),
                 ResizeIfNeededInterpolateTorch(keys=["img", "seg"], out_size=(512, 512), mode_map={"img": "bilinear", "seg": "nearest"}, antialias_map={"img": True}),
         ])  
+        # needed for rare-class-only based score
+        self.rare_classes = [2, 3, 4, 5, 6]
+        self.val_rare_intersections = []
+        self.val_rare_denominators = []
 
     def configure_optimizers(self):
         optimizer = torch.optim.Adam(self.parameters(), lr=self.hparams.lr)
@@ -509,12 +438,53 @@ class TTUNet(pl.LightningModule):
         y = val_batch["seg"]
         
         y = y.to(torch.int64)
-        x = self.model(x)
+        logits = self.model(x)
+    
+        loss = self.loss(logits, y)
         
-        loss = self.loss(x, y)
-        
-        batch_size = x.shape[0]
+        batch_size = logits.shape[0]
         self.log('val_loss', loss, batch_size=batch_size, sync_dist=True)
+        
+        # rare-class based score & whole validation dataset
+    
+        pred = torch.argmax(logits, dim=1)  # [B, H, W]
+        true = y.squeeze(1) if y.ndim == 4 else y  # [B, H, W]
+    
+        intersections = []
+        denominators = []
+    
+        for c in self.rare_classes:
+            pred_c = pred == c
+            true_c = true == c
+    
+            intersections.append((pred_c & true_c).sum().float())
+            denominators.append(pred_c.sum().float() + true_c.sum().float())
+    
+        self.val_rare_intersections.append(torch.stack(intersections))
+        self.val_rare_denominators.append(torch.stack(denominators))
+    
+    def on_validation_epoch_end(self):
+        if len(self.val_rare_intersections) == 0:
+            return
+    
+        intersections = torch.stack(self.val_rare_intersections).sum(dim=0)
+        denominators = torch.stack(self.val_rare_denominators).sum(dim=0)
+    
+        dice_per_class = torch.where(
+            denominators > 0,
+            2.0 * intersections / denominators,
+            torch.zeros_like(denominators),
+        )
+    
+        val_rare_dice = dice_per_class.mean()
+    
+        self.log("val_rare_dice", val_rare_dice, prog_bar=True, sync_dist=True)
+    
+        for i, c in enumerate(self.rare_classes):
+            self.log( f"val_dice_class_{c}", dice_per_class[i], prog_bar=False, sync_dist=True)
+    
+        self.val_rare_intersections.clear()
+        self.val_rare_denominators.clear()
 
     def test_step(self, test_batch, batch_idx):
         x = test_batch["img"]

--- a/src/py/segmentation_predict_pkl.py
+++ b/src/py/segmentation_predict_pkl.py
@@ -1,0 +1,288 @@
+import SimpleITK as sitk
+import numpy as np
+import argparse
+from collections import namedtuple
+
+import torch
+import torch.nn.functional as F
+
+import os
+import sys
+import pandas as pd
+
+## edit to support pkl import file
+import pickle
+
+class bcolors:
+    HEADER = '\033[95m'
+    OK = '\033[94m'
+    INFO = '\033[96m'
+    SUCCESS = '\033[92m'
+    WARNING = '\033[93m'
+    FAIL = '\033[91m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+def _resize_with_grid_sample(
+    x: torch.Tensor,
+    out_hw: tuple[int, int],
+    mode: str,
+    align_corners: bool = False,
+) -> torch.Tensor:
+    """
+    x: (N,C,H,W) tensor
+    out_hw: (H_out, W_out)
+    mode: 'bilinear' for images/logits, 'nearest' for label maps
+    """
+    assert x.ndim == 4, f"Expected (N,C,H,W), got {x.shape}"
+
+    mesh_grid_params = [torch.arange(start=-1.0, end=1.0, step=(2.0/s), device=x.device) for s in out_hw]
+    mesh_grid = torch.stack(torch.meshgrid(mesh_grid_params, indexing='xy'), dim=-1).to(torch.float32).unsqueeze(0)
+
+    y = F.grid_sample(
+        x, mesh_grid,
+        mode=mode,
+        padding_mode="zeros",
+        align_corners=align_corners,
+    )
+    return y
+
+@torch.no_grad()
+def run_segmentation_resize_roundtrip(
+    model,
+    img: torch.Tensor,
+    *,
+    in_hw: tuple[int, int] = (512, 512),
+    align_corners: bool = False
+):
+    """
+    img: (N,C,H,W)
+    Returns:
+      - logits_back: (N,K,H,W) if return_logits=True
+      - or labels_back: (N,1,H,W) long tensor if return_logits=False
+    """
+    assert img.ndim == 4, f"Expected (N,C,H,W), got {img.shape}"
+    n, c, h0, w0 = img.shape
+
+    # 1) resize to model input
+    img_512 = _resize_with_grid_sample(
+        img, in_hw, mode="nearest", align_corners=align_corners
+    )
+
+    # 2) run model (expects 512x512)
+    logits_512 = model(img_512)  # (N,K,512,512) typically
+
+    # 3) resize back to original size
+    logits = _resize_with_grid_sample(
+        logits_512.float(), (w0, h0), mode="nearest", align_corners=align_corners
+    )
+
+    # If you want discrete labels, do argmax at original resolution
+    labels = torch.argmax(logits, dim=1, keepdim=True).to(torch.long)  # (N,1,H,W)
+    return labels, img_512, logits_512
+
+def map_seg(seg: torch.Tensor) -> torch.Tensor:
+    """
+    seg: (N,1,H,W) float tensor in [0,1]
+    Returns:
+      seg_rgb: (N,3,H,W) float tensor in [0,1]
+    """
+    assert seg.ndim == 4 and seg.shape[1] == 1, f"Expected (N,1,H,W), got {seg.shape}"
+    color_map = torch.tensor(
+        [
+            [0, 0, 0],        # class 0: black
+            [255, 0, 0],      # class 1: red
+            [0, 255, 0],      # class 2: green
+            [0, 0, 255],      # class 3: blue
+            [255, 255, 0],    # class 4: yellow
+            [255, 0, 255],    # class 5: magenta
+            [0, 255, 255],    # class 6: cyan
+            [255, 165, 0],    # class 7: orange
+        ],
+        device=seg.device,
+        dtype=torch.float32
+    ) / 255.0  # Normalize to [0,1]
+
+    N, _, H, W = seg.shape
+    seg_long = seg.long().squeeze(1)  # (N,H,W)
+    seg_rgb = color_map[seg_long]     # (N,H,W,3)
+    seg_rgb = seg_rgb.permute(0, 3, 1, 2)  # (N,3,H,W)
+    return seg_rgb
+
+def blend(img: torch.Tensor, seg: torch.Tensor, alpha: float = 0.5) -> torch.Tensor:
+    """
+    img: (N,3,H,W) float tensor in [0,1]
+    seg: (N,1,H,W) float tensor in [0,1]
+    """
+    assert img.ndim == 4 and img.shape[1] == 3, f"Expected (N,3,H,W), got {img.shape}"
+    assert seg.ndim == 4 and seg.shape[1] == 1, f"Expected (N,1,H,W), got {seg.shape}"
+    seg_rgb = map_seg(seg)
+    blended = (1.0 - alpha) * img + alpha * seg_rgb
+    blended = torch.clamp(blended, 0.0, 1.0)
+    return blended
+
+def main(args): 
+
+    device = torch.device("cuda:0")
+
+    model_seg = torch.jit.load(args.model, map_location=device)
+    model_seg.eval()
+
+    img_out = []
+
+    if args.csv:
+        
+        df = pd.read_csv(args.csv)
+
+        for idx, row in df.iterrows():
+
+            img_path = row[args.img_column]
+
+            if args.csv_root and not os.path.isabs(img_path):
+                img_path = os.path.join(args.csv_root, img_path)
+            
+            out_d = {'img': img_path}
+
+            img = row[args.img_column]
+
+            out_seg = None
+
+            if args.out:
+
+                ext = os.path.splitext(img)[1]
+                out_seg = os.path.normpath(os.path.join(args.out, img)).replace(ext, ".nrrd")                    
+
+                out_seg_dir = os.path.dirname(out_seg)
+
+                if not os.path.exists(out_seg_dir):
+                    os.makedirs(out_seg_dir)
+
+                out_d['seg'] = out_seg
+            else:
+                out_d['seg'] = None
+
+            if args.out_composite:
+
+                out_comp = os.path.normpath(os.path.join(args.out_composite, img))                    
+
+                out_comp_dir = os.path.dirname(out_comp)
+
+                if not os.path.exists(out_comp_dir):
+                    os.makedirs(out_comp_dir)
+                
+                out_d['out_composite'] = out_comp
+            
+            if args.ow or (not os.path.exists(out_seg)):
+                img_out.append(out_d)
+
+        
+
+        if len(img_out) == 0:
+            print(bcolors.INFO, "All images have been processed!", bcolors.ENDC)
+            quit()
+
+        df_out = pd.DataFrame(img_out)
+        df['seg'] = df_out['seg']        
+        csv_split_ext = os.path.splitext(args.csv)
+        out_csv = csv_split_ext[0] + "_seg" + csv_split_ext[1]
+        df.to_csv(out_csv, index=False)
+
+    else:
+        img_out.append({'img': args.img})
+
+    for obj in img_out:
+
+        try:
+            print(bcolors.INFO, "Reading:", obj["img"], bcolors.ENDC)
+
+            if obj["img"].endswith(".pkl"):
+                with open(obj["img"], "rb") as f:
+                    d = pickle.load(f)
+            
+                img_np = d["img"]
+            
+                if torch.is_tensor(img_np):
+                    img_t = img_np.float()
+                else:
+                    img_t = torch.from_numpy(img_np).float()
+            
+                # handle shapes:
+                # possible: [1,3,H,W], [3,H,W], or [H,W,3]
+                if img_t.ndim == 4:
+                    img_t = img_t.squeeze(0)
+            
+                if img_t.ndim == 3 and img_t.shape[0] != 3 and img_t.shape[-1] == 3:
+                    img_t = img_t.permute(2, 0, 1)
+            
+                img_t = img_t.unsqueeze(0).cuda()
+            
+                # normalize only if needed
+                if img_t.max() > 1:
+                    img_t = img_t / 255.0
+            
+                sitk_img = None
+            
+            else:
+                sitk_img = sitk.ReadImage(obj["img"])
+                img_np = sitk.GetArrayFromImage(sitk_img)
+                img_t = torch.from_numpy(img_np).permute(2, 0, 1).unsqueeze(0).float().cuda() / 255.0
+            
+            seg_t, img_512, logits_512 = run_segmentation_resize_roundtrip(model_seg, img_t)
+
+            if obj["seg"] is not None:
+                print(bcolors.SUCCESS, "Writing:", obj["seg"], bcolors.ENDC)
+                
+                seg = sitk.GetImageFromArray(seg_t.squeeze(0).squeeze(0).cpu().numpy().astype(np.uint8))
+
+                if sitk_img is not None:
+                    seg.CopyInformation(sitk_img)
+
+                writer = sitk.ImageFileWriter()
+                writer.SetFileName(obj["seg"])
+                writer.UseCompressionOn()
+                writer.Execute(seg)
+
+            if obj.get("out_composite") is not None:
+                print(bcolors.SUCCESS, "Writing:", obj.get("out_composite"), bcolors.ENDC)
+
+                seg_512 = torch.argmax(logits_512, dim=1, keepdim=True).float()
+                composite_t = blend(img_512, seg_512, alpha=args.alpha)
+                composite_64 = _resize_with_grid_sample(
+                    composite_t, (64,64), mode="nearest", align_corners=False
+                ).squeeze()
+                composite_64 = (composite_64.permute(1,2,0).cpu().numpy()*255.0).astype(np.uint8)
+                
+                composite = sitk.GetImageFromArray(composite_64, isVector=True)
+
+                writer = sitk.ImageFileWriter()
+                writer.SetFileName(obj.get("out_composite"))
+                writer.UseCompressionOn()
+                writer.Execute(composite)
+            
+        except Exception as e:
+            print(bcolors.FAIL, e, bcolors.ENDC, file=sys.stderr)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Prediction the segmentation only', formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    input_group = parser.add_argument_group('Input parameters')
+
+    in_group = input_group.add_mutually_exclusive_group(required=True)
+    in_group.add_argument('--img', type=str, help='Input image for prediction')
+    in_group.add_argument('--csv', type=str, help='CSV file with images. Uses column name "image"')
+    parser.add_argument('--csv_root', type=str, help='Root path to replace for output', default=None)
+    parser.add_argument('--img_column', type=str, help='Name of column in csv file', default="img")
+    
+    parser.add_argument('--model', type=str, help='Segmentation pytorch script model', default='/work/jprieto/data/remote/EGower/trained_models/segmentation/v5.3/epoch=189-val_loss=0.17.pt')
+    
+
+    output_group = parser.add_argument_group('Output parameters')
+    output_group.add_argument('--out', type=str, help='Output dir', default=None)
+    output_group.add_argument('--out_composite', type=str, help='Output for composite images', default=None)
+    output_group.add_argument('--alpha', type=float, help='Alpha blending factor for composite images', default=0.7)
+    output_group.add_argument('--ow', type=bool, help='Overwrite outputs', default=False)    
+
+    args = parser.parse_args()
+    main(args)

--- a/src/py/segmentation_train_yin.py
+++ b/src/py/segmentation_train_yin.py
@@ -1,0 +1,152 @@
+import os
+# os.environ['CUDA_VISIBLE_DEVICES']="0"
+import argparse
+
+import math
+import pandas as pd
+import numpy as np 
+
+import torch
+torch.set_float32_matmul_precision('medium')
+
+from nets.segmentation import TTUNet,TTRCNN
+from loaders.tt_dataset import TTDataModuleSeg, TrainTransformsSeg, EvalTransformsSeg, TTDataModuleSegPkl, TTDataModuleSegPklTrans, TTDataModuleSegPklGPUTrans
+from callbacks.logger import SegImageLoggerNeptune, MaskRCNNImageLoggerNeptune
+
+from lightning import Trainer
+from lightning.pytorch.callbacks.early_stopping import EarlyStopping
+from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.strategies.ddp import DDPStrategy
+from lightning.pytorch.loggers import NeptuneLogger
+
+from sklearn.utils import class_weight
+
+def main(args):
+
+    # train_fn = os.path.join(args.mount_point, 'Analysis_Set_202208', 'trachoma_bsl_mtss_besrat_field_seg_train_202208_train.csv')
+    # valid_fn = os.path.join(args.mount_point, 'Analysis_Set_202208', 'trachoma_bsl_mtss_besrat_field_seg_train_202208_eval.csv')
+    # test_fn = os.path.join(args.mount_point, 'Analysis_Set_202208', 'trachoma_bsl_mtss_besrat_field_seg_test_202208.csv')
+
+    df_train = pd.read_csv(args.csv_train)
+    df_val = pd.read_csv(args.csv_valid)
+    df_test = pd.read_csv(args.csv_test)
+    
+
+    # if args.data_module == 'pkl':
+    #     ttdata = TTDataModuleSegPkl(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, mount_point=args.mount_point)
+        
+    # if args.data_module == 'pkl':
+    #    ttdata = TTDataModuleSegPklTrans(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, mount_point=args.mount_point)
+    
+    if args.data_module == 'pkl':
+      ttdata = TTDataModuleSegPklGPUTrans(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, mount_point=args.mount_point)
+
+    else:
+        train_transform = TrainTransformsSeg()
+        eval_transform = EvalTransformsSeg()
+        ttdata = TTDataModuleSeg(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, img_column=args.img_column, seg_column=args.seg_column, mount_point=args.mount_point, train_transform=train_transform, valid_transform=eval_transform, test_transform=eval_transform)
+    
+    
+
+
+    checkpoint_callback = ModelCheckpoint(
+        dirpath=args.out,
+        filename='{epoch}-{val_loss:.2f}',
+        save_top_k=2,
+        monitor='val_loss'
+    )
+    
+    # image_logger = MaskRCNNImageLoggerNeptune(log_steps = args.log_every_n_steps)
+    
+    if args.model:
+        model = TTUNet.load_from_checkpoint(args.model, out_channels=2, **vars(args), strict=False)
+        # model = TTRCNN.load_from_checkpoint(args.model, out_channels=4, **vars(args), strict=False)
+    else:
+        model = TTUNet(**vars(args))
+        # model = TTRCNN(num_classes=4,  **vars(args))
+    
+
+    # ckpt = '/CMF/data/lumargot/trachoma/output/segmentation/first_model/epoch.192-val_loss.0.52.ckpt'
+    # checkpoint = torch.load(ckpt, map_location="cpu")
+
+    # state_dict = checkpoint["state_dict"] if "state_dict" in checkpoint else checkpoint
+    # model_dict = model.state_dict()
+
+    # pretrained_dict = {
+    #     k: v for k, v in state_dict.items()
+    #     if k in model_dict and v.shape == model_dict[k].shape
+    # }
+
+    # print(f"Loaded {len(pretrained_dict)} / {len(model_dict)} layers")
+
+    # # Update and load
+    # model_dict.update(pretrained_dict)
+    # model.load_state_dict(model_dict)
+    
+
+    early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=0.00, patience=args.patience, verbose=True, mode="min")
+    logger = None
+    
+    callbacks = [early_stop_callback, checkpoint_callback]
+    if args.neptune_tags:
+        logger = NeptuneLogger(project='ImageMindAnalytics/trachoma',
+                               tags=args.neptune_tags,
+                               api_key=os.environ['NEPTUNE_API_TOKEN'],
+                               log_model_checkpoints=False)
+
+        image_logger = SegImageLoggerNeptune(num_images=4, nrow=2, log_steps=args.log_every_n_steps)
+        callbacks.append(image_logger)
+
+    trainer = Trainer(
+        logger=logger,
+        max_epochs=args.epochs,
+        callbacks=callbacks,
+        devices=torch.cuda.device_count(), 
+        accelerator="gpu", 
+        strategy=DDPStrategy(find_unused_parameters=False) if torch.cuda.device_count() > 1 else 'auto',
+        log_every_n_steps=args.log_every_n_steps, 
+        accumulate_grad_batches=args.accumulate_grad_batches
+    )
+    trainer.fit(model, datamodule=ttdata, ckpt_path=args.model)
+    trainer.test(model, datamodule=ttdata)
+
+
+if __name__ == '__main__':
+
+
+    parser = argparse.ArgumentParser(description='TT segmentation Training')
+
+    input_group = parser.add_argument_group('Input')
+    input_group.add_argument('--data_module', help='Data module to use', type=str, default="tt", choices=["pkl","tt"])
+    input_group.add_argument('--model', help='Model to continue training', type=str, default= None)
+    input_group.add_argument('--mount_point', help='Dataset mount directory', type=str, default="./")    
+    input_group.add_argument('--num_workers', help='Number of workers for loading', type=int, default=4)
+    input_group.add_argument('--csv_train', required=True, type=str, help='Train CSV')
+    input_group.add_argument('--csv_valid', required=True, type=str, help='Valid CSV')
+    input_group.add_argument('--csv_test', required=True, type=str, help='Test CSV')
+    input_group.add_argument('--img_column', type=str, default="img_path", help='Name of image column in csv')
+    input_group.add_argument('--seg_column', type=str, default="seg_path", help='Name of segmentation column in csv')
+
+    hparams_group = parser.add_argument_group('Hyperparameters')
+    hparams_group.add_argument('--lr', '--learning-rate', default=1e-4, type=float, help='Learning rate')
+    hparams_group.add_argument('--epochs', help='Max number of epochs', type=int, default=200)
+    hparams_group.add_argument('--patience', help='Max number of patience steps for EarlyStopping', type=int, default=30)
+    hparams_group.add_argument('--steps', help='Max number of steps per epoch', type=int, default=-1)    
+    hparams_group.add_argument('--batch_size', help='Batch size', type=int, default=256)
+    hparams_group.add_argument('--out_channels', help='Number of output channels', type=int, default=4)
+    hparams_group.add_argument('--ce_weight', help='Cross entropy weight', type=float, default=None, nargs='+')
+    hparams_group.add_argument('--accumulate_grad_batches', help='Number of gradient accumulation steps', type=int, default=1) 
+    
+    logger_group = parser.add_argument_group('Logger')
+    logger_group.add_argument('--log_every_n_steps', help='Log every n steps', type=int, default=10)
+    logger_group.add_argument('--tb_dir', help='Tensorboard output dir', type=str, default=None)
+    logger_group.add_argument('--tb_name', help='Tensorboard experiment name', type=str, default="segmentation_unet")
+    
+    logger_group.add_argument('--neptune_tags', help='neptune tag', type=str, nargs='+', default=None)
+
+    output_group = parser.add_argument_group('Output')
+    output_group.add_argument('--out', help='Output', type=str, default="./")
+
+    args = parser.parse_args()
+
+    main(args)

--- a/src/py/segmentation_trainweight_yin.py
+++ b/src/py/segmentation_trainweight_yin.py
@@ -52,12 +52,8 @@ def main(args):
     
 
 
-    checkpoint_callback = ModelCheckpoint(
-        dirpath=args.out,
-        filename='{epoch}-{val_loss:.2f}',
-        save_top_k=2,
-        monitor='val_loss'
-    )
+    checkpoint_callback = ModelCheckpoint(dirpath=args.out, filename='{epoch}-{val_loss:.2f}', save_top_k=2, monitor='val_loss' )
+    checkpoint_callback = ModelCheckpoint(dirpath=args.out, filename='{epoch}-{val_rare_dice:.4f}', save_top_k=2, monitor='val_rare_dice', mode='max')
     
     # image_logger = MaskRCNNImageLoggerNeptune(log_steps = args.log_every_n_steps)
     
@@ -87,7 +83,9 @@ def main(args):
     # model.load_state_dict(model_dict)
     
 
-    early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=0.00, patience=args.patience, verbose=True, mode="min")
+    # early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=0.00, patience=args.patience, verbose=True, mode="min")
+    early_stop_callback = EarlyStopping(monitor="val_rare_dice", min_delta=0.00, patience=args.patience, verbose=True, mode="max")
+    
     logger = None
     
     callbacks = [early_stop_callback, checkpoint_callback]

--- a/src/py/segmentation_trainweight_yin.py
+++ b/src/py/segmentation_trainweight_yin.py
@@ -1,0 +1,155 @@
+import os
+# os.environ['CUDA_VISIBLE_DEVICES']="0"
+import argparse
+
+import math
+import pandas as pd
+import numpy as np 
+
+import torch
+torch.set_float32_matmul_precision('medium')
+
+from nets.segmentation import TTUNet,TTRCNN
+from loaders.tt_dataset import TTDataModuleSeg, TrainTransformsSeg, EvalTransformsSeg, TTDataModuleSegPkl, TTDataModuleSegPklTrans, TTDataModuleSegPklGPUResize
+from callbacks.logger import SegImageLoggerNeptune, MaskRCNNImageLoggerNeptune
+
+from lightning import Trainer
+from lightning.pytorch.callbacks.early_stopping import EarlyStopping
+from lightning.pytorch.callbacks import ModelCheckpoint
+from lightning.pytorch.strategies.ddp import DDPStrategy
+from lightning.pytorch.loggers import NeptuneLogger
+
+from sklearn.utils import class_weight
+
+def main(args):
+
+    # train_fn = os.path.join(args.mount_point, 'Analysis_Set_202208', 'trachoma_bsl_mtss_besrat_field_seg_train_202208_train.csv')
+    # valid_fn = os.path.join(args.mount_point, 'Analysis_Set_202208', 'trachoma_bsl_mtss_besrat_field_seg_train_202208_eval.csv')
+    # test_fn = os.path.join(args.mount_point, 'Analysis_Set_202208', 'trachoma_bsl_mtss_besrat_field_seg_test_202208.csv')
+
+    df_train = pd.read_csv(args.csv_train)
+    df_val = pd.read_csv(args.csv_valid)
+    df_test = pd.read_csv(args.csv_test)
+    
+
+    # if args.data_module == 'pkl':
+    #     ttdata = TTDataModuleSegPkl(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, mount_point=args.mount_point)
+        
+    # if args.data_module == 'pkl':
+    #     ttdata = TTDataModuleSegPklTrans(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, mount_point=args.mount_point)
+    
+
+    # if args.data_module == 'pkl':
+    #     ttdata = TTDataModuleSegPklGPUTrans(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, mount_point=args.mount_point)
+    
+    if args.data_module == 'pkl':
+        ttdata = TTDataModuleSegPklGPUResize(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, mount_point=args.mount_point)
+    else:
+        train_transform = TrainTransformsSeg()
+        eval_transform = EvalTransformsSeg()
+        ttdata = TTDataModuleSeg(df_train, df_val, df_test, batch_size=args.batch_size, num_workers=args.num_workers, img_column=args.img_column, seg_column=args.seg_column, mount_point=args.mount_point, train_transform=train_transform, valid_transform=eval_transform, test_transform=eval_transform)
+    
+    
+
+
+    checkpoint_callback = ModelCheckpoint(
+        dirpath=args.out,
+        filename='{epoch}-{val_loss:.2f}',
+        save_top_k=2,
+        monitor='val_loss'
+    )
+    
+    # image_logger = MaskRCNNImageLoggerNeptune(log_steps = args.log_every_n_steps)
+    
+    if args.model:
+        model = TTUNet.load_from_checkpoint(args.model, out_channels=2, **vars(args), strict=False)
+        # model = TTRCNN.load_from_checkpoint(args.model, out_channels=4, **vars(args), strict=False)
+    else:
+        model = TTUNet(**vars(args))
+        # model = TTRCNN(num_classes=4,  **vars(args))
+    
+
+    # ckpt = '/CMF/data/lumargot/trachoma/output/segmentation/first_model/epoch.192-val_loss.0.52.ckpt'
+    # checkpoint = torch.load(ckpt, map_location="cpu")
+
+    # state_dict = checkpoint["state_dict"] if "state_dict" in checkpoint else checkpoint
+    # model_dict = model.state_dict()
+
+    # pretrained_dict = {
+    #     k: v for k, v in state_dict.items()
+    #     if k in model_dict and v.shape == model_dict[k].shape
+    # }
+
+    # print(f"Loaded {len(pretrained_dict)} / {len(model_dict)} layers")
+
+    # # Update and load
+    # model_dict.update(pretrained_dict)
+    # model.load_state_dict(model_dict)
+    
+
+    early_stop_callback = EarlyStopping(monitor="val_loss", min_delta=0.00, patience=args.patience, verbose=True, mode="min")
+    logger = None
+    
+    callbacks = [early_stop_callback, checkpoint_callback]
+    if args.neptune_tags:
+        logger = NeptuneLogger(project='ImageMindAnalytics/trachoma',
+                               tags=args.neptune_tags,
+                               api_key=os.environ['NEPTUNE_API_TOKEN'],
+                               log_model_checkpoints=False)
+
+        image_logger = SegImageLoggerNeptune(num_images=4, nrow=2, log_steps=args.log_every_n_steps)
+        callbacks.append(image_logger)
+
+    trainer = Trainer(
+        logger=logger,
+        max_epochs=args.epochs,
+        callbacks=callbacks,
+        devices=torch.cuda.device_count(), 
+        accelerator="gpu", 
+        strategy=DDPStrategy(find_unused_parameters=False) if torch.cuda.device_count() > 1 else 'auto',
+        log_every_n_steps=args.log_every_n_steps, 
+        accumulate_grad_batches=args.accumulate_grad_batches
+    )
+    trainer.fit(model, datamodule=ttdata, ckpt_path=args.model)
+    trainer.test(model, datamodule=ttdata)
+
+
+if __name__ == '__main__':
+
+
+    parser = argparse.ArgumentParser(description='TT segmentation Training')
+
+    input_group = parser.add_argument_group('Input')
+    input_group.add_argument('--data_module', help='Data module to use', type=str, default="tt", choices=["pkl","tt"])
+    input_group.add_argument('--model', help='Model to continue training', type=str, default= None)
+    input_group.add_argument('--mount_point', help='Dataset mount directory', type=str, default="./")    
+    input_group.add_argument('--num_workers', help='Number of workers for loading', type=int, default=4)
+    input_group.add_argument('--csv_train', required=True, type=str, help='Train CSV')
+    input_group.add_argument('--csv_valid', required=True, type=str, help='Valid CSV')
+    input_group.add_argument('--csv_test', required=True, type=str, help='Test CSV')
+    input_group.add_argument('--img_column', type=str, default="img_path", help='Name of image column in csv')
+    input_group.add_argument('--seg_column', type=str, default="seg_path", help='Name of segmentation column in csv')
+
+    hparams_group = parser.add_argument_group('Hyperparameters')
+    hparams_group.add_argument('--lr', '--learning-rate', default=1e-4, type=float, help='Learning rate')
+    hparams_group.add_argument('--epochs', help='Max number of epochs', type=int, default=200)
+    hparams_group.add_argument('--patience', help='Max number of patience steps for EarlyStopping', type=int, default=30)
+    hparams_group.add_argument('--steps', help='Max number of steps per epoch', type=int, default=-1)    
+    hparams_group.add_argument('--batch_size', help='Batch size', type=int, default=256)
+    hparams_group.add_argument('--out_channels', help='Number of output channels', type=int, default=4)
+    hparams_group.add_argument('--ce_weight', help='Cross entropy weight', type=float, default=None, nargs='+')
+    hparams_group.add_argument('--accumulate_grad_batches', help='Number of gradient accumulation steps', type=int, default=1) 
+    
+    logger_group = parser.add_argument_group('Logger')
+    logger_group.add_argument('--log_every_n_steps', help='Log every n steps', type=int, default=10)
+    logger_group.add_argument('--tb_dir', help='Tensorboard output dir', type=str, default=None)
+    logger_group.add_argument('--tb_name', help='Tensorboard experiment name', type=str, default="segmentation_unet")
+    
+    logger_group.add_argument('--neptune_tags', help='neptune tag', type=str, nargs='+', default=None)
+
+    output_group = parser.add_argument_group('Output')
+    output_group.add_argument('--out', help='Output', type=str, default="./")
+
+    args = parser.parse_args()
+
+    main(args)

--- a/tt_environment.yml
+++ b/tt_environment.yml
@@ -1,13 +1,10 @@
-name: tt
+name: tt_yin
 channels:
-  - Microsoft
   - defaults
 dependencies:
   - _libgcc_mutex=0.1
   - bzip2=1.0.8
-  - ca-certificates=2024.07.04
   - libffi=3.4.4
-  - openssl=3.3.1
   - python=3.10
   - sqlite=3.45.3
   - tk=8.6.14


### PR DESCRIPTION
The changes made:

To use DiceCE, in src/py/nets/segmentation.py : 
  weight=torch.tensor(self.hparams.ce_weight) to ce_weight=torch.tensor(self.hparams.ce_weight)
  (somehow the whole function get updated)

To adjust to the pkl file format, in src/py/loaders/tt_dataset.py:
  add function TTDataModuleSegPklTrans (resize/rotate/zoom included, on CPU, suffers from computational inefficiency
  add function TTDataModuleSegPklGPUTrans (enables GPU-based transformations to improve training efficiency)
  add function TTDataModuleSegPklGPUResize (refine the GPU-based pipeline by enforcing correct tensor shapes, ensuring compatibility with Dice/DiceCE losses and stable training behavior)

To create my own virtual env, changed tt_environment.yml

Please let me know if there are any comments.